### PR TITLE
Fix sessionControl path comparisons

### DIFF
--- a/biblioteca-digital/middlewares/middlewares.js
+++ b/biblioteca-digital/middlewares/middlewares.js
@@ -2,9 +2,9 @@ module.exports = {
     
     sessionControl(req, res, next) {
         if (req.session.login != undefined) next();
-        else if ((req.url == '/') && (req.method == 'GET ')) next();
-        else if ((req.url == '/ login ') && (req.method == 'POST ')) next();
-        else if ((req.url).split('/')[1] == ' recuperarSenha ') next();
+        else if ((req.url == '/') && (req.method == 'GET')) next();
+        else if ((req.url == '/login') && (req.method == 'POST')) next();
+        else if ((req.url).split('/')[1] == 'recuperarSenha') next();
         else res.redirect('/');
     }
 };


### PR DESCRIPTION
## Summary
- remove stray spaces when checking route and method
- allow middleware to match `/login`, `GET`, `POST`, and `recuperarSenha`

## Testing
- `npm test` (fails: missing script)
- `cd biblioteca-digital && npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_b_6840a404c06c8322bd20f48d3b9c98db