### PR TITLE
Implement logRegister middleware

### DIFF
--- a/biblioteca-digital/app.js
+++ b/biblioteca-digital/app.js
@@ -19,12 +19,12 @@ app.set('view engine', 'handlebars');
 app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 
+app.use(middlewares.logRegister);
+app.use(middlewares.sessionControl);
 app.use(routes);
 
 app.listen(8081, () => {
   console.log("Servidor rodando em http://localhost:8081");
 });
-
-app.use ( middlewares.logRegister, middlewares.sessionControl )
 
 

--- a/biblioteca-digital/middlewares/middlewares.js
+++ b/biblioteca-digital/middlewares/middlewares.js
@@ -1,5 +1,10 @@
 module.exports = {
-    
+    logRegister(req, res, next) {
+        const now = new Date().toISOString();
+        console.log(`[${now}] ${req.method} ${req.originalUrl}`);
+        next();
+    },
+
     sessionControl(req, res, next) {
         if (req.session.login != undefined) next();
         else if ((req.url == '/') && (req.method == 'GET ')) next();


### PR DESCRIPTION
## Summary
- add `logRegister` middleware for simple request logging
- apply `logRegister` and `sessionControl` before routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6840a41b8ecc8322ac787a81f9d44f25